### PR TITLE
ci: auto-merge + release assets

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,40 @@
+name: Auto Merge PRs
+
+on:
+  pull_request_target:
+    types: [labeled, opened, reopened, synchronize, ready_for_review]
+  check_suite:
+    types: [completed]
+  check_run:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      contains(join(fromJSON(toJSON(github.event.pull_request.labels)).*.name, ','), 'automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-merge when ready (label=automerge)
+        uses: peter-evans/auto-merge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: merge
+          delete-branch: true
+          squash-commit-title: pull-request-title
+          squash-commit-message: pull-request-description
+          require-pass: true
+          labels: automerge
+          # オプション: 最低承認者数（ブランチ保護が無い場合のガード）
+          minimum-approvals: 1
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch: {}
 
 jobs:
   build:
+    permissions:
+      contents: write
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,16 @@ jobs:
       - name: Build onefile
         run: |
           pyinstaller inventory-app.spec
-      - name: Upload artifact
+      - name: Upload artifact (workflow artifact)
         uses: actions/upload-artifact@v4
         with:
           name: inventory-app-${{ runner.os }}
           path: dist/**
+      - name: Attach artifacts to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Auto-merge PRs labeled 'automerge' via peter-evans/auto-merge\n- On tag push, upload PyInstaller dist/** to the GitHub Release via softprops/action-gh-release\n\nUsage:\n- To opt-in auto-merge, add the 'automerge' label to a PR.\n- To publish binaries, create a tag like v0.1.2; the workflow builds on 3 OS and attaches artifacts to the tag release.
